### PR TITLE
Support larger PECL release format.

### DIFF
--- a/src/Console/Command/InfoCommand.php
+++ b/src/Console/Command/InfoCommand.php
@@ -18,7 +18,7 @@ class InfoCommand extends Command
         (?<package>\w+)
         (?:
              \-(?<stability>beta|stable|alpha)
-           | @(?<version>(?:\d+(?:\.\d+)*))
+           | @(?<version>(?:\d+(?:\.\d+){1,2})|(?:[1-2]\d{3}[0-1]\d[0-3]\d{1}))
         )?
     $#x';
 


### PR DESCRIPTION
Next episode of https://github.com/pierrejoye/pickle/pull/24.

I have noticed that `RE_PACKAGE` is not used in the code. Is it in readiness of incoming patches (I suspect @jubianchi ;-))?
