### PR TITLE
Use padraic/phar-updater to handle PAHR updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 composer.lock
 composer.phar
-pickle.phar
+pickle*.phar
 vendor/

--- a/bin/pickle
+++ b/bin/pickle
@@ -1,26 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-use Symfony\Component\Console\Input\InputArgument;
-
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
-
-$required_exts = array(
-	"zlib",
-	"mbstring",
-	"simplexml",
-	"json",
-	"dom",
-	"openssl",
-	"phar",
-	"zip",
-);
-foreach ($required_exts as $ext) {
-	if (!extension_loaded($ext)) {
-		die("Extension '$ext' required but not loaded, full required list: " . implode(", ", $required_exts));
-	}
-}
 
 // application.php
 function includeIfExists($file)
@@ -32,22 +14,19 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader
     echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL;
+
     exit(1);
 }
 
-use Pickle\Console\Command;
-use Pickle\Console\Helper;
-use Symfony\Component\Console\Application;
-
- if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-	$name = '
+if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+    $name = '
    ____  _      _    _
   |  _ \(_) ___| | _| | ___
   | |_) | |/ __| |/ / |/ _ \
   |  __/| | (__|   <| |  __/
   |_|   |_|\___|_|\_\_|\___| ';
  } else {
-	$name = '
+    $name = '
  ██████╗ ██╗ ██████╗██╗  ██╗██╗     ███████╗
  ██╔══██╗██║██╔════╝██║ ██╔╝██║     ██╔════╝
  ██████╔╝██║██║     █████╔╝ ██║     █████╗
@@ -55,22 +34,6 @@ use Symfony\Component\Console\Application;
  ██║     ██║╚██████╗██║  ██╗███████╗███████╗
  ╚═╝     ╚═╝ ╚═════╝╚═╝  ╚═╝╚══════╝╚══════╝ ';
 }
-$application = new Application($name, "0.4.0-dev");
 
-$application->getHelperSet()->set(new \Pickle\Console\Helper\PackageHelper());
-
-$application->add(new Command\ValidateCommand);
-$application->add(new Command\ConvertCommand);
-$application->add(new Command\ReleaseCommand);
-$application->add(new Command\InstallerCommand);
-$application->add(new Command\InfoCommand);
-
-/* foreach ($application->all() as $cmd) {
-    $cmd->addOption('format', null, InputArgument::OPTIONAL, 'To output help in other formats', 'txt');
-} */
-
-foreach ($application->all() as $cmd) {
-    $cmd->addOption('tmp-dir', null, InputArgument::OPTIONAL, 'path to a custom temp dir', sys_get_temp_dir());
-}
-
+$application = new Pickle\Console\Application($name);
 $application->run();

--- a/box.json.dist
+++ b/box.json.dist
@@ -31,8 +31,7 @@
             "in": "vendor"
         }
     ],
-    "git-commit": "git-commit",
-    "git-version": "git-version",
+    "git-tag": "pickle-version",
     "main": "bin/pickle",
     "output": "pickle.phar",
     "stub": true

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "ext-zip": "*",
         "symfony/console": "~2.5",
         "justinrainbow/json-schema": "~1.5",
-        "composer/composer": "~1.0-alpha8"
+        "composer/composer": "~1.0-alpha8",
+        "padraic/phar-updater": "~1.0@dev"
     },
     "require-dev": {
         "atoum/atoum": "~2.1",

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Pickle\Console;
+
+use Symfony\Component\Console\Application as BaseApplication;
+use Pickle\Console\Helper;
+
+class Application extends BaseApplication
+{
+    const NAME = 'pickle';
+    const VERSION = '@pickle-version@';
+
+    public function __construct($name = null, $version = null)
+    {
+        self::checkExtensions();
+
+        parent::__construct($name ?: static::NAME, $version ?: (static::VERSION === '@' . 'pickle-version@' ? 'source' : static::VERSION));
+    }
+
+    protected function getDefaultHelperSet()
+    {
+        $helperSet = parent::getDefaultHelperSet();
+
+        $helperSet->set(new Helper\PackageHelper());
+
+        return $helperSet;
+    }
+
+    protected function getDefaultCommands()
+    {
+        $commands = parent::getDefaultCommands();
+
+        $commands[] = new Command\ValidateCommand;
+        $commands[] = new Command\ConvertCommand;
+        $commands[] = new Command\ReleaseCommand;
+        $commands[] = new Command\InstallerCommand;
+        $commands[] = new Command\InfoCommand;
+
+        if (\Phar::running() !== '') {
+            $commands[] = new Command\SelfUpdateCommand;
+        }
+
+        return $commands;
+    }
+
+    private static function checkExtensions()
+    {
+        $required_exts = array(
+            "zlib",
+            "mbstring",
+            "simplexml",
+            "json",
+            "dom",
+            "openssl",
+            "phar",
+            "zip",
+        );
+
+        foreach ($required_exts as $ext) {
+            if (!extension_loaded($ext)) {
+                die("Extension '$ext' required but not loaded, full required list: " . implode(", ", $required_exts));
+            }
+        }
+    }
+}

--- a/src/Console/Command/ConvertCommand.php
+++ b/src/Console/Command/ConvertCommand.php
@@ -39,6 +39,7 @@ namespace Pickle\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Pickle\Package\Command\Convert;
 use Pickle\Base\Util;
@@ -56,6 +57,13 @@ class ConvertCommand extends Command
                 'Path to the PECL extension root directory (default pwd)',
                 getcwd()
             )
+            ->addOption(
+                'tmp-dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to a custom temp dir',
+                sys_get_temp_dir()
+            );
         ;
     }
 

--- a/src/Console/Command/InfoCommand.php
+++ b/src/Console/Command/InfoCommand.php
@@ -39,6 +39,7 @@ namespace Pickle\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Pickle\Base\Interfaces;
 use Pickle\Package\Command\Info;
@@ -56,6 +57,13 @@ class InfoCommand extends Command
                 InputArgument::OPTIONAL,
                 'Path to the PECL extension root directory (default pwd)',
                 getcwd()
+            )
+            ->addOption(
+                'tmp-dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to a custom temp dir',
+                sys_get_temp_dir()
             );
     }
 

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -66,26 +66,37 @@ class InstallerCommand extends BuildCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Do not install extension'
-            )->addOption(
+            )
+            ->addOption(
                 'php',
                 null,
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'path to an alternative php (exec)'
-            )->addOption(
+            )
+            ->addOption(
                 'ini',
                 null,
-                InputArgument::OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'path to an alternative php.ini'
-            )->addOption(
+            )
+            ->addOption(
                 'source',
                 null,
                 InputOption::VALUE_NONE,
                 'use source package'
-            )->addOption(
+            )
+            ->addOption(
                 'save-logs',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'path to save the build logs'
+            )
+            ->addOption(
+                'tmp-dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to a custom temp dir',
+                sys_get_temp_dir()
             );
 
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {

--- a/src/Console/Command/ReleaseCommand.php
+++ b/src/Console/Command/ReleaseCommand.php
@@ -36,7 +36,6 @@
 
 namespace Pickle\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -54,7 +53,7 @@ class ReleaseCommand extends BuildCommand
         $this
             ->setName('release')
             ->setDescription('Package a PECL extension for release')
-        /* TODO: make it to take value like zip, tgz, etc. should this functionality be expanded */
+            /* TODO: make it to take value like zip, tgz, etc. should this functionality be expanded */
             ->addOption(
                 'binary',
                 null,
@@ -66,6 +65,13 @@ class ReleaseCommand extends BuildCommand
                 null,
                 InputOption::VALUE_NONE,
                 'package build logs'
+            )
+            ->addOption(
+                'tmp-dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to a custom temp dir',
+                sys_get_temp_dir()
             );
 
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pickle\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Exception;
+
+class SelfUpdateCommand extends Command
+{
+    const PHAR_NAME = 'pickle.phar';
+
+    protected function configure()
+    {
+        $this
+            ->setName('self-update')
+            ->setDescription('Updates pickle.phar to the latest version.')
+            ->addOption(
+                'unstable',
+                null,
+                InputOption::VALUE_NONE,
+                'Update to a non-stable version'
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $updater = new Updater(null, false, Updater::STRATEGY_GITHUB);
+        $updater->getStrategy()->setPackageName('friendsofphp/pickle');
+        $updater->getStrategy()->setPharName(self::PHAR_NAME);
+        $updater->getStrategy()->setCurrentLocalVersion($this->getApplication()->getVersion());
+
+        if ($input->getOption('unstable')) {
+            $updater->getStrategy()->setStability('unstable');
+        }
+
+        if ($updater->update() === false) {
+            $output->writeln('<info>Already up-to-date.</info>');
+        } else {
+            $output->writeln('<info>' . $updater->getLocalPharFileBasename() . ' has been updated!</info>');
+        }
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Console/Command/ValidateCommand.php
+++ b/src/Console/Command/ValidateCommand.php
@@ -39,6 +39,7 @@ namespace Pickle\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Pickle\Base\Interfaces;
 use Pickle\Package\Command\Validate;
@@ -56,6 +57,13 @@ class ValidateCommand extends Command
                 InputArgument::OPTIONAL,
                 'Path to the PECL extension root directory (default pwd)',
                 getcwd()
+            )
+            ->addOption(
+                'tmp-dir',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'path to a custom temp dir',
+                sys_get_temp_dir()
             );
     }
 


### PR DESCRIPTION
It's been a while since I sent my last contribution. So here is a new one!

It adds a new `self-update` command to pickle letting users update their local Phar when a new release is issued on github with a simple command line: `sudo pickle self-update`

It has currently one option `--unstable` to update to unstable release.
I plan to add a `--rollback` option to let the users revert the update if anything went wrong.

Let me know what you think about it ;)