### PR TITLE
Fix permission issues

### DIFF
--- a/src/Base/Abstracts/Package/Convey/Command.php
+++ b/src/Base/Abstracts/Package/Convey/Command.php
@@ -58,10 +58,7 @@ abstract class Command
 
     abstract protected function prepare();
 
-    public function execute($target, $no_convert)
-    {
-        throw new \Exception('No command::execute implementation found ');
-    }
+    abstract public function execute($target, $no_convert);
 
     public function getPath()
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Pickle;
+
+use Composer;
+
+class Config extends Composer\Config
+{
+    const DEFAULT_BASE_DIRNAME = '.pickle';
+
+    public function __construct($useEnvironment = true, $baseDir = null)
+    {
+        if ($useEnvironment === true) {
+            $baseDir = $baseDir ?: (getenv('PICKLE_BASE_DIR') ?: null);
+        }
+
+        $baseDir = $baseDir ?: (getenv('HOME') ?: sys_get_temp_dir());
+        $baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::DEFAULT_BASE_DIRNAME;
+
+        parent::__construct($useEnvironment, $baseDir);
+    }
+}

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -103,7 +103,7 @@ class InstallerCommand extends BuildCommand
      * @param InputInterface  $input
      * @param OutputInterface $output
      */
-    protected function binaryInstallWindows($path, $input, $output)
+    protected function binaryInstallWindows($path, InputInterface $input, OutputInterface $output)
     {
         $php = Engine::factory();
         $table = new Table($output);
@@ -194,7 +194,7 @@ class InstallerCommand extends BuildCommand
 
         $package = $this->getHelper('package')->convey($input, $output, $path);
 
-    /* TODO Info package command should be used here. */
+        /* TODO Info package command should be used here. */
         $this->getHelper('package')->showInfo($output, $package);
 
         list($optionsValue, $force_opts) = $this->buildOptions($package, $input, $output);

--- a/src/Package/Convey/Command/Factory.php
+++ b/src/Package/Convey/Command/Factory.php
@@ -41,6 +41,12 @@ use Composer\IO\ConsoleIO;
 
 class Factory
 {
+    /**
+     * @param $type
+     * @param $path
+     * @param ConsoleIO $io
+     * @return \Pickle\Base\Abstracts\Package\Convey\Command
+     */
     public static function getCommand($type, $path, ConsoleIO $io)
     {
         switch ($type) {

--- a/src/Package/Convey/Command/Git.php
+++ b/src/Package/Convey/Command/Git.php
@@ -36,7 +36,7 @@
 
 namespace Pickle\Package\Convey\Command;
 
-use Composer\Config;
+use Pickle\Config;
 use Pickle\Base\Abstracts;
 use Pickle\Base\Interfaces;
 use Pickle\Package;

--- a/src/Package/Convey/Command/Pickle.php
+++ b/src/Package/Convey/Command/Pickle.php
@@ -36,7 +36,7 @@
 
 namespace Pickle\Package\Convey\Command;
 
-use Composer\Config;
+use Pickle\Config;
 use Pickle\Base\Abstracts;
 use Pickle\Base\Interfaces;
 use Pickle\Package;

--- a/src/Package/Convey/Command/Tgz.php
+++ b/src/Package/Convey/Command/Tgz.php
@@ -36,7 +36,7 @@
 
 namespace Pickle\Package\Convey\Command;
 
-use Composer\Config;
+use Pickle\Config;
 use Pickle\Base\Interfaces;
 use Pickle\Base\Abstracts;
 use Pickle\Package;

--- a/src/Package/PHP/Convey/Command/Pecl.php
+++ b/src/Package/PHP/Convey/Command/Pecl.php
@@ -36,7 +36,7 @@
 
 namespace Pickle\Package\PHP\Convey\Command;
 
-use Composer\Config;
+use Pickle\Config;
 use Pickle\Base\Interfaces;
 use Pickle\Base\Abstracts;
 use Pickle\Package\PHP;

--- a/tests/units/Config.php
+++ b/tests/units/Config.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Pickle\tests\units;
+
+use atoum;
+use Pickle\Config as TestedClass;
+
+class Config extends atoum
+{
+    public function test__construct()
+    {
+        $this
+            ->given(
+                $this->function->getenv = false,
+                $this->function->sys_get_temp_dir = $tmpDir = 'tmp'
+            )
+            ->when($this->newTestedInstance(false))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($tmpDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->never
+            ->when($this->newTestedInstance(true))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($tmpDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->once
+
+            ->given($this->function->getenv = function($var) use (& $baseDir) { return $var === 'PICKLE_BASE_DIR' ? $baseDir = uniqid() : false; })
+            ->when($this->newTestedInstance(false))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($tmpDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->once
+            ->when($this->newTestedInstance(true))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($baseDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->twice
+
+            ->given($this->function->getenv = function($var) use (& $baseDir, & $homeDir) {
+                    return $var === 'PICKLE_BASE_DIR' ? $baseDir = uniqid() : $homeDir = uniqid();
+                }
+            )
+            ->when($this->newTestedInstance(false))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($homeDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->twice
+            ->when($this->newTestedInstance(true))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($baseDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->thrice
+
+            ->when($this->newTestedInstance(false, $baseDir = uniqid()))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($baseDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->thrice
+
+            ->when($this->newTestedInstance(true, $baseDir = uniqid()))
+            ->then
+                ->string($this->testedInstance->get('vendor-dir'))->isEqualTo($this->makePath($baseDir, TestedClass::$defaultConfig['vendor-dir']))
+                ->function('getenv')
+                    ->wasCalledWithArguments('PICKLE_BASE_DIR')->thrice
+        ;
+    }
+
+    private function makePath($head, $tail)
+    {
+        return $head . DIRECTORY_SEPARATOR . TestedClass::DEFAULT_BASE_DIRNAME . DIRECTORY_SEPARATOR . $tail;
+    }
+}


### PR DESCRIPTION
Pickle now uses its own sandbox to download extensions' sources :

* Defaults to `~/.pickle`
* Fallbacks to `$TMPDIR/.pickle`

Closes #123