### PR TITLE
Issue with http

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Pickle fully supports existing extensions in http://pecl.php.net, running the fo
 $ bin/pickle install memcache
 ```
 
+Use the sudo command on Mac or Linux if you are having problems with the install.
+
 Windows is fully supported, to install binaries or from the sources (work in progress and given that you have a working build environment in place).
 
 The concept behind Pickle is to ease the life of both developers and end users.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-dom": "*",
         "ext-openssl": "*",
         "ext-zip": "*",
-        "symfony/console": "~2.5",
+        "symfony/console": "~2.5|~3.0",
         "justinrainbow/json-schema": "~1.5",
         "composer/composer": "~1.0-alpha8",
         "padraic/phar-updater": "~1.0@dev"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -286,7 +286,7 @@ class FeatureContext implements SnippetAcceptingContext
      */
     public function extensionExists($name, $version)
     {
-        $url = 'http://pecl.php.net/get/' . $name . '/' . $version;
+        $url = 'https://pecl.php.net/get/' . $name . '/' . $version;
         $file = $name . '-' . $version . '.tgz';
         $dir = $this->workingDir . '/' . basename($file, '.tgz');
 

--- a/src/Base/Abstracts/Package.php
+++ b/src/Base/Abstracts/Package.php
@@ -40,8 +40,15 @@ use Composer\Package\CompletePackage;
 use Pickle\Package\Util\Header;
 use Composer\Package\Version\VersionParser;
 
+/**
+ * Class Package
+ * @package Pickle\Base\Abstracts
+ */
 class Package extends CompletePackage
 {
+    /**
+     * @return string
+     */
     public function getSimpleName()
     {
         $full_name = $this->getName();
@@ -53,6 +60,9 @@ class Package extends CompletePackage
         return $m[2];
     }
 
+    /**
+     *
+     */
     public function getVendorName()
     {
         $full_name = $this->getName();
@@ -64,6 +74,9 @@ class Package extends CompletePackage
         return $m[1];
     }
 
+    /**
+     * @return string
+     */
     public function getUniqueNameForFs()
     {
         return sha1($this->getUniqueName());
@@ -73,6 +86,9 @@ class Package extends CompletePackage
         other engines. Lets see if this is needed to be
         moved into the Interface so each engines package
         is forced to implement it on its own. But so far ... */
+    /**
+     *
+     */
     public function updateVersion()
     {
         /* Be sure package root is set before! */

--- a/src/Base/Abstracts/Package/Build.php
+++ b/src/Base/Abstracts/Package/Build.php
@@ -58,6 +58,7 @@ abstract class Build
     /**
      * @param int    $level
      * @param string $msg
+     * @param string $hint
      */
     public function log($level, $msg, $hint = '')
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,10 +4,22 @@ namespace Pickle;
 
 use Composer;
 
+/**
+ * Class Config
+ * @package Pickle
+ */
 class Config extends Composer\Config
 {
+    /**
+     *
+     */
     const DEFAULT_BASE_DIRNAME = '.pickle';
 
+    /**
+     * Config constructor.
+     * @param bool $useEnvironment
+     * @param null $baseDir
+     */
     public function __construct($useEnvironment = true, $baseDir = null)
     {
         if ($useEnvironment === true) {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -5,11 +5,27 @@ namespace Pickle\Console;
 use Symfony\Component\Console\Application as BaseApplication;
 use Pickle\Console\Helper;
 
+/**
+ * Class Application
+ * @package Pickle\Console
+ */
 class Application extends BaseApplication
 {
+    /**
+     *
+     */
     const NAME = 'pickle';
+
+    /**
+     *
+     */
     const VERSION = '@pickle-version@';
 
+    /**
+     * Application constructor.
+     * @param null $name
+     * @param null $version
+     */
     public function __construct($name = null, $version = null)
     {
         self::checkExtensions();
@@ -17,6 +33,9 @@ class Application extends BaseApplication
         parent::__construct($name ?: static::NAME, $version ?: (static::VERSION === '@' . 'pickle-version@' ? 'source' : static::VERSION));
     }
 
+    /**
+     * @return \Symfony\Component\Console\Helper\HelperSet
+     */
     protected function getDefaultHelperSet()
     {
         $helperSet = parent::getDefaultHelperSet();
@@ -26,6 +45,9 @@ class Application extends BaseApplication
         return $helperSet;
     }
 
+    /**
+     * @return array|\Symfony\Component\Console\Command\Command[]
+     */
     protected function getDefaultCommands()
     {
         $commands = parent::getDefaultCommands();
@@ -43,6 +65,9 @@ class Application extends BaseApplication
         return $commands;
     }
 
+    /**
+     *
+     */
     private static function checkExtensions()
     {
         $required_exts = array(

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -113,6 +113,7 @@ class InstallerCommand extends BuildCommand
      * @param string          $path
      * @param InputInterface  $input
      * @param OutputInterface $output
+     * @throws \Exception
      */
     protected function binaryInstallWindows($path, InputInterface $input, OutputInterface $output)
     {

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -9,10 +9,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Humbug\SelfUpdate\Updater;
 use Humbug\SelfUpdate\Exception;
 
+/**
+ * Class SelfUpdateCommand
+ * @package Pickle\Console\Command
+ */
 class SelfUpdateCommand extends Command
 {
+    /**
+     *
+     */
     const PHAR_NAME = 'pickle.phar';
 
+    /**
+     *
+     */
     protected function configure()
     {
         $this
@@ -27,6 +37,10 @@ class SelfUpdateCommand extends Command
         ;
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $updater = new Updater(null, false, Updater::STRATEGY_GITHUB);

--- a/src/Console/Helper/PackageHelper.php
+++ b/src/Console/Helper/PackageHelper.php
@@ -98,8 +98,8 @@ class PackageHelper extends Helper
     /**
      * @param InputInterface  $input
      * @param OutputInterface $output
-     * @param $url
-     * @param $path
+     * @param string $path
+     * @param $target
      *
      * @return Pickle\Base\Interfaces\Package
      */

--- a/src/Engine/HHVM/Ini.php
+++ b/src/Engine/HHVM/Ini.php
@@ -50,7 +50,8 @@ class Ini extends Abstracts\Engine\Ini implements Interfaces\Engine\Ini
 
     /**
      * @param string $pickleSection
-     * @param array  $dsos
+     * @param array  $dsos_add
+     * @param array $dsos_del
      *
      * @return string
      */

--- a/src/Engine/PHP/Ini.php
+++ b/src/Engine/PHP/Ini.php
@@ -50,8 +50,8 @@ class Ini extends Abstracts\Engine\Ini implements Interfaces\Engine\Ini
 
     /**
      * @param string $pickleSection
-     * @param array  $dlls
-     *
+     * @param array  $dlls_add
+     * @param array $dlls_del
      * @return string
      */
     protected function rebuildPickleParts($pickleSection, array $dlls_add, array $dlls_del = array())

--- a/src/Package/Convey.php
+++ b/src/Package/Convey.php
@@ -41,10 +41,22 @@ use Pickle\Package\Convey\Command\Factory;
 use Pickle\Package\Convey\Command\Type;
 use Pickle\Base\Util;
 
+/**
+ * Class Convey
+ * @package Pickle\Package
+ */
 class Convey
 {
+    /**
+     * @var \Pickle\Base\Abstracts\Package\Convey\Command
+     */
     protected $command;
 
+    /**
+     * Convey constructor.
+     * @param $path
+     * @param ConsoleIO $io
+     */
     public function __construct($path, ConsoleIO $io)
     {
         if (!$path) {
@@ -55,6 +67,11 @@ class Convey
         $this->command = Factory::getCommand($type, $path, $io);
     }
 
+    /**
+     * @param string $target
+     * @param bool $no_convert
+     * @return mixed
+     */
     public function deliver($target = '', $no_convert = false)
     {
         $target = $target ? realpath($target) : Util\TmpDir::get().DIRECTORY_SEPARATOR.$this->command->getName();

--- a/src/Package/PHP/Command/Build/Windows.php
+++ b/src/Package/PHP/Command/Build/Windows.php
@@ -58,6 +58,7 @@ class Windows extends Abstracts\Package\Build implements Interfaces\Package\Buil
 
     /**
      * @param string $src
+     * @param string $dest
      */
     private function copySrcDir($src, $dest)
     {

--- a/src/Package/PHP/Command/Install/Windows/Binary.php
+++ b/src/Package/PHP/Command/Install/Windows/Binary.php
@@ -95,6 +95,8 @@ class Binary
 
     /**
      * @param string $url
+     * @param string $toFind
+     * @return mixed
      */
     private function findInLinks($url, $toFind)
     {

--- a/src/Package/PHP/Command/Install/Windows/Binary.php
+++ b/src/Package/PHP/Command/Install/Windows/Binary.php
@@ -254,7 +254,7 @@ class Binary
      */
     private function getInfoFromPecl()
     {
-        $url = 'http://pecl.php.net/get/'.$this->extName;
+        $url = 'https://pecl.php.net/get/'.$this->extName;
         $headers = get_headers($url);
 
         if (strpos($headers[0], '404') !== false) {

--- a/src/Package/PHP/Command/Release.php
+++ b/src/Package/PHP/Command/Release.php
@@ -42,6 +42,10 @@ use Pickle\Package\PHP\Util\PackageXml;
 use Pickle\Package\Util\Header;
 use Composer\Package\Version\VersionParser;
 
+/**
+ * Class Release
+ * @package Pickle\Package\PHP\Command
+ */
 class Release implements Interfaces\Package\Release
 {
     /**
@@ -49,8 +53,8 @@ class Release implements Interfaces\Package\Release
      */
     protected $pkg = null;
 
-    /*
-     * @var Closure
+    /**
+     * @var null|\Closure
      */
     protected $cb = null;
 
@@ -63,7 +67,7 @@ class Release implements Interfaces\Package\Release
      * Constructor.
      *
      * @param string  $path
-     * @param Closure $cb
+     * @param \Closure|null $cb
      * @param bool    $noConvert
      */
     public function __construct($path, $cb = null, $noConvert = false)
@@ -73,6 +77,11 @@ class Release implements Interfaces\Package\Release
         $this->noConvert = $noConvert;
     }
 
+    /**
+     * @param $path
+     * @return null|Package\Util\JSON\Pickle\Base\Interfaces\Package
+     * @throws \Exception
+     */
     protected function readPackage($path)
     {
         $jsonLoader = new Package\Util\JSON\Loader(new Package\Util\Loader());
@@ -120,6 +129,7 @@ class Release implements Interfaces\Package\Release
 
     /**
      * Create package.
+     * @param array $args
      */
     public function create(array $args = array())
     {
@@ -155,6 +165,9 @@ class Release implements Interfaces\Package\Release
         }
     }
 
+    /**
+     *
+     */
     public function packLog()
     {
         /* pass, no logging seems to be happening here yet */

--- a/src/Package/PHP/Command/Release/Windows/Binary.php
+++ b/src/Package/PHP/Command/Release/Windows/Binary.php
@@ -41,6 +41,10 @@ use Pickle\Package;
 use Pickle\Package\PHP\Util\PackageXml;
 use Pickle\Package\Util\Header;
 
+/**
+ * Class Binary
+ * @package Pickle\Package\PHP\Command\Release\Windows
+ */
 class Binary implements Interfaces\Package\Release
 {
     /**
@@ -48,17 +52,17 @@ class Binary implements Interfaces\Package\Release
      */
     protected $pkg = null;
 
-    /*
-     * @var Closure
+    /**
+     * @var null|\Closure
      */
     protected $cb = null;
 
-    /*
+    /**
      * @var bool
      */
     protected $noConvert = false;
 
-    /*
+    /**
      * @var Interfaces\Package\Build
      */
     protected $build;
@@ -67,7 +71,7 @@ class Binary implements Interfaces\Package\Release
      * Constructor.
      *
      * @param string  $path
-     * @param Closure $cb
+     * @param \Closure|null $cb
      * @param bool    $noConvert
      */
     public function __construct($path, $cb = null, $noConvert = false)
@@ -77,11 +81,19 @@ class Binary implements Interfaces\Package\Release
         $this->noConvert = $noConvert;
     }
 
+    /**
+     * @throws \Exception
+     */
     public function __destruct()
     {
         $this->composerJsonBak($this->pkg, true);
     }
 
+    /**
+     * @param Interfaces\Package $pkg
+     * @param bool $restore
+     * @throws \Exception
+     */
     protected function composerJsonBak(\Pickle\Base\Interfaces\Package $pkg, $restore = false)
     {
         $composer_json_orig = $pkg->getRootDir().DIRECTORY_SEPARATOR.'composer.json';
@@ -102,6 +114,11 @@ class Binary implements Interfaces\Package\Release
         }
     }
 
+    /**
+     * @param $path
+     * @return null|Package\Util\JSON\Pickle\Base\Interfaces\Package
+     * @throws \Exception
+     */
     protected function readPackage($path)
     {
         $jsonLoader = new Package\Util\JSON\Loader(new Package\Util\Loader());
@@ -125,7 +142,7 @@ class Binary implements Interfaces\Package\Release
                 $jsonPath = $pkgXml->getJsonPath();
 
                 $package = $jsonLoader->load($jsonPath);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 /* pass for now, be compatible */
             }
         }
@@ -147,6 +164,10 @@ class Binary implements Interfaces\Package\Release
         return $package;
     }
 
+    /**
+     * @param Interfaces\Package\Build $build
+     * @return string
+     */
     protected function getZipBaseName(Interfaces\Package\Build $build)
     {
         $info = $build->getInfo();
@@ -162,6 +183,7 @@ class Binary implements Interfaces\Package\Release
 
     /**
      * Create package.
+     * @param array $args
      */
     public function create(array $args = array())
     {
@@ -250,6 +272,10 @@ class Binary implements Interfaces\Package\Release
         $zip->close();
     }
 
+    /**
+     * @param Interfaces\Package\Build|null $build
+     * @return string
+     */
     public function packLog(Interfaces\Package\Build $build = null)
     {
         if (!$build) {
@@ -263,6 +289,9 @@ class Binary implements Interfaces\Package\Release
         return realpath($path);
     }
 
+    /**
+     * @return array
+     */
     public function getMultiExtensionNames()
     {
         $info = $this->build->getInfo();

--- a/src/Package/PHP/Package.php
+++ b/src/Package/PHP/Package.php
@@ -39,6 +39,10 @@ namespace Pickle\Package\PHP;
 use Pickle\Base\Abstracts;
 use Pickle\Base\Util\GitIgnore;
 
+/**
+ * Class Package
+ * @package Pickle\Package\PHP
+ */
 class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Package
 {
     /**
@@ -58,7 +62,7 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
 
     /**
      * Get the package's root directory.
-     *
+     * @throws \Exception
      * @return string
      */
     public function getSourceDir()
@@ -92,12 +96,16 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
         $this->path = $path;
     }
 
+    /**
+     * @param $stability
+     */
     public function setStability($stability)
     {
         $this->stability = $stability;
     }
 
     /**
+     * @throws \Exception
      * @return array
      */
     public function getConfigureOptions()
@@ -130,6 +138,10 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
         return $options;
     }
 
+    /**
+     * @param $file
+     * @return array
+     */
     public function getConfigureOptionsFromFile($file)
     {
         $config = file_get_contents($file);
@@ -281,6 +293,10 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
         );
     }
 
+    /**
+     * @return array
+     * @throws \Exception
+     */
     public function getVersionFromHeader()
     {
         $headers = glob($this->path.DIRECTORY_SEPARATOR.'*.h');
@@ -306,6 +322,10 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
         return [trim($version_define), $version];
     }
 
+    /**
+     * @param $path
+     * @return bool
+     */
     protected function extConfigIsIn($path)
     {
         if (defined('PHP_WINDOWS_VERSION_MAJOR') !== false) {
@@ -317,6 +337,9 @@ class Package extends Abstracts\Package implements \Pickle\Base\Interfaces\Packa
         }
     }
 
+    /**
+     * @param $path
+     */
     protected function locateSourceDirByExtConfig($path)
     {
         $it = new \RecursiveIteratorIterator(

--- a/src/Package/PHP/Util/ConvertChangeLog.php
+++ b/src/Package/PHP/Util/ConvertChangeLog.php
@@ -36,9 +36,19 @@
 
 namespace Pickle\Package\PHP\Util;
 
+/**
+ * Class ConvertChangeLog
+ * @package Pickle\Package\PHP\Util
+ */
 class ConvertChangeLog
 {
+    /**
+     * @var string
+     */
     private $path;
+    /**
+     * @var
+     */
     private $changelog;
 
     /**
@@ -53,6 +63,9 @@ class ConvertChangeLog
         $this->path = $path;
     }
 
+    /**
+     *
+     */
     public function parse()
     {
         $xml = @simplexml_load_file($this->path);
@@ -76,6 +89,9 @@ class ConvertChangeLog
         $this->changelog = $changelog;
     }
 
+    /**
+     *
+     */
     public function generateReleaseFile()
     {
         if (empty($this->changelog)) {

--- a/src/Package/PHP/Util/XML/Loader.php
+++ b/src/Package/PHP/Util/XML/Loader.php
@@ -51,7 +51,7 @@ class Loader
 
     /**
      * @param string $path
-     *
+     * @throws \InvalidArgumentException|\RuntimeException|\Exception
      * @return Pickle\Base\Interfaces\Package
      */
     public function load($path)

--- a/src/Package/Util/Dumper.php
+++ b/src/Package/Util/Dumper.php
@@ -42,6 +42,7 @@ class Dumper
 {
     /**
      * @param \Pickle\Base\Interfaces\Package $package
+     * @param bool $with_version
      *
      * @return array
      */

--- a/src/Package/Util/JSON/Dumper.php
+++ b/src/Package/Util/JSON/Dumper.php
@@ -43,7 +43,7 @@ class Dumper
 {
     /**
      * @param \Pickle\Base\Interfaces\Package $package
-     *
+     * @param bool $with_version
      * @return string
      */
     public function dump(Interfaces\Package $package, $with_version = true)
@@ -53,6 +53,8 @@ class Dumper
 
     /**
      * @param \Pickle\Base\Interfaces\Package $package
+     * @param string $path
+     * @param bool $with_version
      * @param string                          $path
      */
     public function dumpToFile(Interfaces\Package $package, $path, $with_version = true)

--- a/tests/units/Package/Convey/Command/Type.php
+++ b/tests/units/Package/Convey/Command/Type.php
@@ -119,7 +119,7 @@ class Type extends atoum
         $this
             ->string(Command\Type::determine("https://github.com/DomBlack/php-scrypt/archive/v1.2.tar.gz", true))
                 ->isIdenticalTo(Command\Type::TGZ)
-            ->string(Command\Type::determine("http://pecl.php.net/get/sync-1.0.1.tgz", true))
+            ->string(Command\Type::determine("https://pecl.php.net/get/sync-1.0.1.tgz", true))
                 ->isIdenticalTo(Command\Type::TGZ)
             ->string(Command\Type::determine("some_ext-1.2.3a.tgz", false))
                 ->isIdenticalTo(Command\Type::TGZ);


### PR DESCRIPTION
Changed the http protocol to https for pecl.php.net.  Fixed an issue with updating because composer complained about non-secure access.  Updated the readme to reflect that some users might have to use sudo to get commands to work.

Could not do this for windows.php.net since it seems to be missing a server listening to that port, the connection hangs up if you try to curl https://windows.php.net  

Updated the doc blocks since it seems things are missing or incorrectly documented in a few places.
