### PR TITLE
Change the default version of the phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Clone this repository and install the dependencies with
 $ composer install
 ```
 
-A [phar is also available](https://github.com/FriendsOfPHP/pickle/releases/download/v0.2.0/pickle.phar).
+A [phar is also available](https://github.com/FriendsOfPHP/pickle/releases/download/v0.4.0/pickle.phar), but it might be outdated.
 
 If you like to create your own phar from the pickle sources, you will need to install Box (http://box-project.github.io/box2/). Then clone the repository and run the following commands:
 


### PR DESCRIPTION
I've updated the default version of the phar in the README, but as the last version is outdated, I've also added a warning about that. People should really use the latest master version.