### PR TITLE
Update vendor namespace for php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "atoum/visibility-extension": "~1.0",
         "behat/behat": "~3.0",
         "symfony/process": "~2.5",
-        "fabpot/php-cs-fixer": "~1.7"
+        "friendsofphp/php-cs-fixer": "~1.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello, current vendor namespace for php-cs-fixer is `friendsofphp`.

Thanks for checking this out or considering merging it...