### PR TITLE
Add User-Agent header when fetching PECL websites, closes #162

### DIFF
--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -259,7 +259,7 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
 
     public function getExtensionDir()
     {
-        return $this->extensionDir;
+        return dirname($this->getPath()) . DIRECTORY_SEPARATOR . $this->extensionDir;
     }
 
     public function getIniPath()

--- a/src/Package/PHP/Command/Install/Windows/Binary.php
+++ b/src/Package/PHP/Command/Install/Windows/Binary.php
@@ -98,7 +98,13 @@ class Binary
      */
     private function findInLinks($url, $toFind)
     {
-        $page = @file_get_contents($url);
+        $opts = [
+            'http' => [
+                'header' => 'User-Agent: pickle'
+            ],
+        ];
+        $context = stream_context_create($opts);
+        $page = @file_get_contents($url, false, $context);
         if (!$page) {
             return false;
         }
@@ -182,7 +188,11 @@ class Binary
         $progress = $this->progress;
 
         $ctx = stream_context_create(
-            array(),
+            array(
+                'http' => [
+                    'header' => 'User-Agent: pickle'
+                ]
+            ),
             array(
                 'notification' => function ($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax) use ($output, $progress) {
                     switch ($notificationCode) {

--- a/src/Package/Util/Windows/DependencyLib.php
+++ b/src/Package/Util/Windows/DependencyLib.php
@@ -70,7 +70,13 @@ class DependencyLib
         $dllMap = null;
 
         if (is_null($this->dllMap)) {
-            $data = @file_get_contents(self::DLL_MAP_URL);
+            $opts = [
+                'http' => [
+                    'header' => 'User-Agent: pickle'
+                ]
+            ];
+            $context = stream_context_create($opts);
+            $data = @file_get_contents(self::DLL_MAP_URL, false, $context);
             if (!$data) {
                 throw new \RuntimeException('Cannot fetch the DLL mapping file');
             }


### PR DESCRIPTION
Would be even better to use a common HTTP client like Guzzle, but I don't even know if this project is still being activly maintained. I just did what was need to work on my machine, don't know if the `getExtensionDir()` method will break on Linux, sorry.