### PR TITLE
Check existence and executability of unescaped filename

### DIFF
--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -58,11 +58,10 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
 
     public function __construct($phpCli = PHP_BINARY)
     {
-        $phpCli = escapeshellcmd($phpCli);
         if (!(is_file($phpCli) && is_executable($phpCli))) {
             throw new \Exception("Invalid php executable: $phpCli");
         }
-        $this->phpCli = $phpCli;
+        $this->phpCli = escapeshellcmd($phpCli);
         $this->getFromConstants();
     }
 


### PR DESCRIPTION
`is_file()` and `is_executable()` can't handle shell escaped filenames,
what is a particular problem on Windows; e.g. `C:\php\php.exe` is shell
escaped as `C:^\php^\php.exe`.