### PR TITLE
Properly detect compiler on Windows

### DIFF
--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -160,9 +160,18 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
         $compiler = '';
 
         foreach ($info as $s) {
-            if (false !== strpos($s, 'Compiler')) {
-                list(, $compiler) = explode('=>', $s);
-                break;
+            if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+                if (false !== strpos($s, 'PHP Extension Build')) {
+                    list(, $build) = explode('=>', $s);
+                    list(, , $compiler) = explode(',', $build);
+                    $compiler = strtolower($compiler);
+                    break;
+                }
+            } else {
+                if (false !== strpos($s, 'Compiler')) {
+                    list(, $compiler) = explode('=>', $s);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
At least for the binary PECL package downloads, the compiler on Windows
has to be something like "vc15" or "vs16".  However, the PHP info
reports the compiler as something like "Visual C++ 2017".  Instead of
mapping this information back to what we need, we use the "PHP
Extension Build" info, which already contains the desired compiler
name.