### PR TITLE
Re-enable dynamic compiler detection on Windows

### DIFF
--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -211,7 +211,7 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
         $iniPath = $this->getIniPathFromPhpInfo($info);
         $extensionDir = $this->getExtensionDirFromPhpInfo($info);
 
-        $compiler = "vc15";
+        $compiler = strtolower($this->getCompilerFromPhpInfo($info));
         return [$compiler, $arch, $iniPath, $extensionDir];
     }
 


### PR DESCRIPTION
On Windows, `::getCompilerFromPhpInfo()` returns the third part of the
PHP Extension Build, i.e. "VC15" or "VS16" for currently supported MSVC
versions (could also be "clang" or "icc", but these are not officially
supported anyway).  So we can simply use this information instead of
having to hard-code the compiler.