### PR TITLE
Made Windows script easier to understand in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ On windows, use
 $ php pickle.phar
 ```
 or create a .bat containing:
-```sh
+```
 @echo OFF
-:: in case DelayedExpansion is on and a path contains ! 
 setlocal DISABLEDELAYEDEXPANSION
-c:\path\to\php.exe "%~dp0composer.phar" %*
+c:\path\to\php.exe "c:\path\to\pickle.phar" %*
 ```
 
 If someone would be kind enough to write an installer script, we would be eternally thankful :)


### PR DESCRIPTION
First, it was written "composer.phar", and second, it's not clear to newcomers what `%~dp0` means, so let's remove it and let people write a clean full path here :)