### PR TITLE
Add download script to always get latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Pickle installs PHP extensions easily on all platforms.
 
 Installation
 ------------
-Grab the latest phar at https://github.com/FriendsOfPHP/pickle/releases/latest and runs using
+Grab the latest phar at https://github.com/FriendsOfPHP/pickle/releases/latest 
+```sh
+wget https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar
+```
+
+and run using
 ```sh
 $ php pickle.phar
 ```


### PR DESCRIPTION
The user does not necessarily know what the latest version is nor has to visit releases pages to copy link of latest phar as long as the attachment is named `pickle.phar` always - which it should be