### PR TITLE
Add option to override the detected version of a package

### DIFF
--- a/features/pecl/git-extension.feature
+++ b/features/pecl/git-extension.feature
@@ -86,3 +86,28 @@ Feature: download and install extensions from git repository
       | url                                 | extension | version |
       | git://github.com/beberlei/env.git   | env       | master  |
       | https://github.com/beberlei/env.git | env       | v0.2.1  |
+
+  Scenario Outline: Show info about extensions with version override
+    Given I run "pickle info --version-override=1.0.0 <url>#<version>"
+    Then it should pass
+    And the output should contain:
+      """
+      - Installing <extension> (<version>)
+      """
+    And the output should contain:
+      """
+      Cloning <version>
+      """
+    And the output should contain:
+      """
+      Package name                      | <extension>
+      """
+    And the output should contain:
+      """
+      Package version (current release) | 1.0.0
+      """
+
+    Examples:
+      | url                                 | extension | version |
+      | git://github.com/beberlei/env.git   | env       | master  |
+      | https://github.com/beberlei/env.git | env       | v0.2.1  |

--- a/features/pecl/info-extensions.feature
+++ b/features/pecl/info-extensions.feature
@@ -45,3 +45,17 @@ Feature: download and install PECL extensions
       """
       | with | for Oracle Database OCI8 support |         |
       """
+
+  Scenario Outline: Override an extensions version
+    When I run "pickle info --version-override=1.0.0 <extension>"
+    Then it should pass
+    And the output should contain:
+      """
+      Package version (current release) | 1.0.0
+      """
+    Examples:
+      | extension |
+      | apcu      |
+      | sqlsrv    |
+      | swoole    |
+      | yaml      |

--- a/src/Base/Abstracts/Package.php
+++ b/src/Base/Abstracts/Package.php
@@ -73,10 +73,12 @@ class Package extends CompletePackage
         other engines. Lets see if this is needed to be
         moved into the Interface so each engines package
         is forced to implement it on its own. But so far ... */
-    public function updateVersion()
+    public function updateVersion($version = null)
     {
         /* Be sure package root is set before! */
-        $version = new Header\Version($this);
+        if ($version === null) {
+            $version = new Header\Version($this);
+        }
         $parser = new VersionParser();
 
         $this->version = $parser->normalize($version);

--- a/src/Base/Abstracts/Package/Convey/Command.php
+++ b/src/Base/Abstracts/Package/Convey/Command.php
@@ -58,7 +58,7 @@ abstract class Command
 
     abstract protected function prepare();
 
-    abstract public function execute($target, $no_convert);
+    abstract public function execute($target, $no_convert, $versionOverride);
 
     public function getPath()
     {

--- a/src/Base/Interfaces/Package/Convey/Command.php
+++ b/src/Base/Interfaces/Package/Convey/Command.php
@@ -42,7 +42,7 @@ interface Command
 {
     public function __construct($path, ConsoleIO $io);
 
-    public function execute($target, $no_convert);
+    public function execute($target, $no_convert, $versionOverride);
 
     public function getType();
 }

--- a/src/Base/Interfaces/Package/Convey/DefaultExecutor.php
+++ b/src/Base/Interfaces/Package/Convey/DefaultExecutor.php
@@ -42,7 +42,7 @@ interface DefaultExecutor
 {
     public function __construct(Interfaces\Package\Convey\Command $command);
 
-    public function execute($target, $no_convert);
+    public function execute($target, $no_convert, $versionOverride);
 }
 
 /* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Console/Command/InfoCommand.php
+++ b/src/Console/Command/InfoCommand.php
@@ -64,6 +64,12 @@ class InfoCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'path to a custom temp dir',
                 sys_get_temp_dir()
+            )
+            ->addOption(
+                'version-override',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override detected version'
             );
     }
 

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -97,6 +97,12 @@ class InstallerCommand extends BuildCommand
                 InputOption::VALUE_REQUIRED,
                 'path to a custom temp dir',
                 sys_get_temp_dir()
+            )
+            ->addOption(
+                'version-override',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override detected version'
             );
 
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {

--- a/src/Console/Helper/PackageHelper.php
+++ b/src/Console/Helper/PackageHelper.php
@@ -109,8 +109,9 @@ class PackageHelper extends Helper
         $io = new ConsoleIO($input, $output, ($helperSet ? $helperSet : new HelperSet()));
 
         $no_convert = $input->hasOption('no-convert') ? $input->getOption('no-convert') : false;
+        $versionOverride = $input->hasOption('version-override') ? $input->getOption('version-override') : null;
 
-        return (new Convey($path, $io))->deliver($target, $no_convert);
+        return (new Convey($path, $io))->deliver($target, $no_convert, $versionOverride);
     }
 }
 

--- a/src/Package/Convey.php
+++ b/src/Package/Convey.php
@@ -55,11 +55,11 @@ class Convey
         $this->command = Factory::getCommand($type, $path, $io);
     }
 
-    public function deliver($target = '', $no_convert = false)
+    public function deliver($target = '', $no_convert = false, $versionOverride = null)
     {
         $target = $target ? realpath($target) : Util\TmpDir::get().DIRECTORY_SEPARATOR.$this->command->getName();
 
-        return $this->command->execute($target, $no_convert);
+        return $this->command->execute($target, $no_convert, $versionOverride);
     }
 }
 

--- a/src/Package/Convey/Command/Any.php
+++ b/src/Package/Convey/Command/Any.php
@@ -46,7 +46,7 @@ class Any extends Abstracts\Package\Convey\Command implements Interfaces\Package
         throw new \Exception('Unsupported package type');
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         throw new \Exception('Unsupported package type');
     }

--- a/src/Package/Convey/Command/DefaultExecutor.php
+++ b/src/Package/Convey/Command/DefaultExecutor.php
@@ -62,7 +62,7 @@ class DefaultExecutor implements Interfaces\Package\Convey\DefaultExecutor
         $this->command = $command;
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverride)
     {
         throw new \Exception('Default executor cannot be used without concrete implementation');
     }

--- a/src/Package/Convey/Command/Git.php
+++ b/src/Package/Convey/Command/Git.php
@@ -91,13 +91,13 @@ class Git extends Abstracts\Package\Convey\Command implements Interfaces\Package
         }
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         $this->fetch($target);
 
         $exe = DefaultExecutor::factory($this);
 
-        return $exe->execute($target, $no_convert);
+        return $exe->execute($target, $no_convert, $versionOverrideOverride);
     }
 
     public function getType()

--- a/src/Package/Convey/Command/Pickle.php
+++ b/src/Package/Convey/Command/Pickle.php
@@ -127,13 +127,13 @@ class Pickle extends Abstracts\Package\Convey\Command implements Interfaces\Pack
         }
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         $this->fetch($target);
 
         $exe = DefaultExecutor::factory($this);
 
-        return $exe->execute($target, $no_convert);
+        return $exe->execute($target, $no_convert, $versionOverrideOverride);
     }
 
     public function getType()

--- a/src/Package/Convey/Command/SrcDir.php
+++ b/src/Package/Convey/Command/SrcDir.php
@@ -46,14 +46,14 @@ class SrcDir extends Abstracts\Package\Convey\Command implements Interfaces\Pack
         $this->url = $this->path;
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         /* Override target, otherwise we'd need to copy ext root each time */
         $target = realpath($this->path);
 
         $exe = DefaultExecutor::factory($this);
 
-        return $exe->execute($target, $no_convert);
+        return $exe->execute($target, $no_convert, $versionOverrideOverride);
     }
 
     public function getType()

--- a/src/Package/Convey/Command/Tgz.php
+++ b/src/Package/Convey/Command/Tgz.php
@@ -65,13 +65,13 @@ class Tgz extends Abstracts\Package\Convey\Command implements Interfaces\Package
         }
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         $this->fetch($target);
 
         $exe = DefaultExecutor::factory($this);
 
-        return $exe->execute($target, $no_convert);
+        return $exe->execute($target, $no_convert, $versionOverrideOverride);
     }
 
     public function getType()

--- a/src/Package/PHP/Convey/Command/DefaultExecutor.php
+++ b/src/Package/PHP/Convey/Command/DefaultExecutor.php
@@ -46,7 +46,7 @@ class DefaultExecutor implements Interfaces\Package\Convey\DefaultExecutor
     {
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverride)
     {
         $jsonLoader = new \Pickle\Package\Util\JSON\Loader(new \Pickle\Package\Util\Loader());
         $pickle_json = $target.DIRECTORY_SEPARATOR.'composer.json';
@@ -61,7 +61,7 @@ class DefaultExecutor implements Interfaces\Package\Convey\DefaultExecutor
         }
 
         if (null === $package) {
-            $pkgXml = new PackageXml($target);
+            $pkgXml = new PackageXml($target, $versionOverride);
             $pkgXml->dump();
 
             $jsonPath = $pkgXml->getJsonPath();
@@ -71,7 +71,7 @@ class DefaultExecutor implements Interfaces\Package\Convey\DefaultExecutor
         }
 
         $package->setRootDir($target);
-        $package->updateVersion();
+        $package->updateVersion($versionOverride);
 
         return $package;
     }

--- a/src/Package/PHP/Convey/Command/Pecl.php
+++ b/src/Package/PHP/Convey/Command/Pecl.php
@@ -93,13 +93,13 @@ class Pecl extends Abstracts\Package\Convey\Command implements Interfaces\Packag
         unset($package, $downloader);
     }
 
-    public function execute($target, $no_convert)
+    public function execute($target, $no_convert, $versionOverrideOverride)
     {
         $this->fetch($target);
 
         $exe = new DefaultExecutor($this);
 
-        return $exe->execute($target, $no_convert);
+        return $exe->execute($target, $no_convert, $versionOverrideOverride);
     }
 
     public function getType()

--- a/src/Package/PHP/Util/PackageXml.php
+++ b/src/Package/PHP/Util/PackageXml.php
@@ -45,8 +45,9 @@ class PackageXml
     protected $xmlPath = null;
     protected $jsonPath = null;
     protected $package = null;
+    protected $versionOverride = null;
 
-    public function __construct($path)
+    public function __construct($path, $versionOverride = null)
     {
         $names = ['package2.xml', 'package.xml' ];
 
@@ -63,12 +64,13 @@ class PackageXml
         }
 
         $this->jsonPath = $path.DIRECTORY_SEPARATOR.'composer.json';
+        $this->versionOverride = $versionOverride;
     }
 
     public function load()
     {
         $loader = new Package\PHP\Util\XML\Loader(new Package\Util\Loader());
-        $this->package = $loader->load($this->xmlPath);
+        $this->package = $loader->load($this->xmlPath, $this->versionOverride);
 
         if (!$this->package) {
             throw new \Exception("Failed to load '{$this->xmlPath}'");
@@ -98,7 +100,7 @@ class PackageXml
             $this->jsonPath = $fname;
         }
 
-        $version = new Header\Version($this->package);
+        $version = $this->versionOverride ?? new Header\Version($this->package);
         if ($version != $this->package->getPrettyVersion()) {
             throw new \Exception("Version mismatch - '".$version."' != '".$this->package->getVersion().'. in source vs JSON');
         }

--- a/src/Package/PHP/Util/XML/Loader.php
+++ b/src/Package/PHP/Util/XML/Loader.php
@@ -54,7 +54,7 @@ class Loader
      *
      * @return Pickle\Base\Interfaces\Package
      */
-    public function load($path)
+    public function load($path, $versionOverride = null)
     {
         if (false === is_file($path)) {
             throw new \InvalidArgumentException('File not found: '.$path);
@@ -77,7 +77,7 @@ class Loader
 
         $package = [
             'name' => (string) $xml->name,
-            'version' => (string) $xml->version->release,
+            'version' => $versionOverride ?? (string) $xml->version->release,
             'stability' => (string) $xml->stability->release,
             'description' => (string) $xml->summary,
         ];
@@ -136,7 +136,7 @@ class Loader
         }
         $ret_pkg->setRootDir(dirname($path));
 
-        $src_ver = new Header\Version($ret_pkg);
+        $src_ver = $versionOverride ?? new Header\Version($ret_pkg);
         if ($src_ver != $ret_pkg->getPrettyVersion()) {
             throw new \Exception("Version mismatch - '".$src_ver."' != '".$ret_pkg->getPrettyVersion()."' in source vs. XML");
         }


### PR DESCRIPTION
Useful when working with pecl packages that have versions that are not semvar compatible, and when installing from source many packages are detected incorrectly.

Would fix https://github.com/FriendsOfPHP/pickle/issues/188, https://github.com/FriendsOfPHP/pickle/issues/165

There are many examples of existing pecl extensions that have versions that have problems. Given that PHP 7.4 deprecates pecl, it would be great if pickle could be used to install all extensions, not just those that conveniently have composer compatible version numbers.

Particularly when installing from source this is difficult as pecl extensions don't tend to handle this very well.

- imagick https://github.com/Imagick/imagick/blob/master/php_imagick.h#L28
- xdebug https://github.com/xdebug/xdebug/blob/master/php_xdebug.h#L23 vs https://github.com/xdebug/xdebug/blob/master/package.xml#L39
- sqlsrv - https://github.com/FriendsOfPHP/pickle/issues/165#issuecomment-683357585
- swool - https://github.com/FriendsOfPHP/pickle/issues/165#issue-556057646
- yaml - https://github.com/FriendsOfPHP/pickle/issues/188#issue-680027694