### PR TITLE
Minimal changes required to make the release command work

### DIFF
--- a/src/Package/PHP/Command/Release.php
+++ b/src/Package/PHP/Command/Release.php
@@ -36,6 +36,7 @@
 
 namespace Pickle\Package\PHP\Command;
 
+use Closure;
 use Pickle\Base\Interfaces;
 use Pickle\Package;
 use Pickle\Package\PHP\Util\PackageXml;
@@ -76,7 +77,7 @@ class Release implements Interfaces\Package\Release
 
     protected function readPackage($path)
     {
-        $package = PackageJson::readPackage($path, $noconvert);
+        $package = PackageJson::readPackage($path, $this->noConvert);
         $package->setRootDir(realpath($path));
 
         /* We're not adding any versions into the composer.json for the source release.

--- a/src/Package/PHP/Command/Release/Windows/Binary.php
+++ b/src/Package/PHP/Command/Release/Windows/Binary.php
@@ -106,7 +106,7 @@ class Binary implements Interfaces\Package\Release
 
     protected function readPackage($path)
     {
-        $package = PackageJson::readPackage($path, $noconvert);
+        $package = PackageJson::readPackage($path, $this->noConvert);
         $this->composerJsonBak($package);
 
         /* For the binary release, json badly need the version informatio

--- a/src/Package/PHP/Util/PackageJson.php
+++ b/src/Package/PHP/Util/PackageJson.php
@@ -42,7 +42,7 @@ use Pickle\Package\Util\Header;
 
 class PackageJson
 {
-    protected function readPackage($path, $noconvert)
+    public static function readPackage($path, $noconvert)
     {
         $jsonLoader = new Package\Util\JSON\Loader(new Package\Util\Loader());
         $package = null;
@@ -74,6 +74,8 @@ class PackageJson
         }
 
         $package->setRootDir(realpath($path));
+
+        return $package;
     }
 }
 

--- a/src/Package/Util/JSON/Loader.php
+++ b/src/Package/Util/JSON/Loader.php
@@ -50,7 +50,7 @@ class Loader
     /**
      * @param string $path
      *
-     * @return Pickle\Base\Interfaces\Package
+     * @return \Pickle\Base\Interfaces\Package
      */
     public function load($path)
     {


### PR DESCRIPTION
Fixes invalid call to protected method `Pickle\Package\PHP\Util\PackageJson::readPackage`.

I stumbled upon this bug when trying to make a test release of an extension for php 8. Seems this class needs a more thorough refactor, but at least these changes make the `pickle release` command work.

```
Fatal error: Uncaught Error: Call to protected method Pickle\Package\PHP\Util\PackageJson::readPackage() from scope Pickle\Package\PHP\Command\Release in phar:///usr/local/bin/pickle/src/Package/PHP/Command/Release.php:79
```