### PR TITLE
fix processing for RC version

### DIFF
--- a/src/Package/Util/Dumper.php
+++ b/src/Package/Util/Dumper.php
@@ -36,6 +36,7 @@
 
 namespace Pickle\Package\Util;
 
+use Composer\Semver\VersionParser;
 use Pickle\Base\Interfaces;
 
 class Dumper
@@ -53,9 +54,10 @@ class Dumper
 
         if ($with_version) {
             $data['version'] = $package->getPrettyVersion();
+            $version_stability = VersionParser::parseStability($data['version']);
             $stability = $package->getStability();
 
-            if ('stable' !== $stability) {
+            if ('stable' !== $stability && 'RC' !== $version_stability) {
                 $data['version'] .= '-' . $stability;
             }
         }

--- a/src/Package/Util/Dumper.php
+++ b/src/Package/Util/Dumper.php
@@ -53,13 +53,7 @@ class Dumper
         $data['name'] = $package->getPrettyName();
 
         if ($with_version) {
-            $data['version'] = $package->getPrettyVersion();
-            $version_stability = VersionParser::parseStability($data['version']);
-            $stability = $package->getStability();
-
-            if ('stable' !== $stability && 'RC' !== $version_stability) {
-                $data['version'] .= '-' . $stability;
-            }
+            $data['version'] = $this->getVersion($package);
         }
 
         $data['type'] = $package->getType();
@@ -85,6 +79,23 @@ class Dumper
         }
 
         return $data;
+    }
+
+    /**
+     * @param Interfaces\Package $package
+     *
+     * @return string
+     */
+    private function getVersion(Interfaces\Package $package): string
+    {
+        $version = $package->getPrettyVersion();
+        $version_stability = VersionParser::parseStability($version);
+        $stability = $package->getStability();
+
+        if ('beta' === $stability && 'stable' === $version_stability) {
+            return $version . '-' . $stability;
+        }
+        return $version;
     }
 }
 


### PR DESCRIPTION
If the stability is determined to be beta in Dumper,
the error occurred with the VersionParser of https://github.com/composer/semver
if `-beta` is added to the version of RC.

e.g.) xdebug-beta 3.0.0RC1
> 3.0.0RC1-beta

FriendsOfPHP/pickle#191
FriendsOfPHP/pickle#200