### PR TITLE
Use system zip/unzip commands (if available)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "ext-zip": "*",
         "symfony/console": "^5.0",
         "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
         "composer/composer": "<2.0",

--- a/src/Base/Abstracts/Package/Build.php
+++ b/src/Base/Abstracts/Package/Build.php
@@ -36,7 +36,9 @@
 
 namespace Pickle\Base\Abstracts\Package;
 
+use Pickle\Base\Archive;
 use Pickle\Base\Util\FileOps;
+use Pickle\Base\Interfaces;
 use Pickle\Base\Interfaces\Package;
 
 abstract class Build
@@ -144,11 +146,9 @@ abstract class Build
     /* zip is default */
     public function packLog($path)
     {
-        $zip = new \ZipArchive();
-        if (!$zip->open($path, \ZipArchive::CREATE | \ZipArchive::OVERWRITE)) {
-            throw new \Exception("Failed to open '$path' for writing");
-        }
-
+        $zipperClass = Archive\Factory::getZipperClassName();
+        $zip = new $zipperClass($path, Interfaces\Archive\Zipper::FLAG_CREATE_OVERWRITE);
+        /** @var $zip \Pickle\Base\Interfaces\Archive\Zipper */
         $no_hint_logs = '';
         foreach ($this->log as $item) {
             $msg = $this->fixEol($item['msg']);
@@ -161,8 +161,6 @@ abstract class Build
         if ($no_hint_logs) {
             $zip->addFromString('build.log', $this->fixEol($item['msg']));
         }
-
-        $zip->close();
     }
 
     /**

--- a/src/Base/Archive/Factory.php
+++ b/src/Base/Archive/Factory.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use RuntimeException;
+
+class Factory
+{
+    /**
+     * Get the fully-qualified name of a class implementing the Zipper interface
+     *
+     * @throws \RuntimeException if no zipper is available.
+     */
+    public static function getZipperClassName(): string
+    {
+        if (static::isInfozipZipAvailable()) {
+            return InfozipZipper::class;
+        }
+        if (static::isZipExtensionAvailable()) {
+            return PHPZipper::class;
+        }
+        throw new RuntimeException(self::buildErrorMessage('zip'));
+    }
+
+    /**
+     * Get the fully-qualified name of a class implementing the Unzipper interface
+     *
+     * @throws \RuntimeException if no zipper is available.
+     */
+    public static function getUnzipperClassName(): string
+    {
+        if (static::isInfozipUnzipAvailable()) {
+            return InfozipUnzipper::class;
+        }
+        if (static::isZipExtensionAvailable()) {
+            return PHPUnzipper::class;
+        }
+        throw new RuntimeException(self::buildErrorMessage('unzip'));
+    }
+
+    public static function isZipExtensionAvailable(): bool
+    {
+        return extension_loaded('zip');
+    }
+
+    public static function isInfozipZipAvailable(): bool
+    {
+        $output = [];
+        $rc = -1;
+        exec('zip -v 2>&1', $output, $rc);
+        return $rc === 0 && preg_match('/info.?zip/i', $output[0] ?? '');
+    }
+
+    public static function isInfozipUnzipAvailable(): bool
+    {
+        $output = [];
+        $rc = -1;
+        exec('unzip -v 2>&1', $output, $rc);
+        return $rc === 0 && preg_match('/info.?zip/i', $output[0] ?? '');
+    }
+
+    private static function buildErrorMessage(string $command): string
+    {
+        $message = <<<EOT
+No support for ZIP files has been detected.
+You have two options:
+1. enable the zip PHP extension
+2. install the {$command} system command
+
+EOT
+        ;
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $message .= "You can find the Windows {$command}.exe program at the following address:\nftp://ftp.info-zip.org/pub/infozip/win32/";
+        } else {
+            $message .= <<<EOT
+For example, to install the {$command} command you may try to run
+apt-get install {$command}
+or
+apk add {$command}
+EOT
+            ;
+        }
+
+        return $message;
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/Infozip.php
+++ b/src/Base/Archive/Infozip.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use RuntimeException;
+
+abstract class Infozip
+{
+    private const FILE_SIGNATURE = "PK\x03\x04";
+
+    /**
+     * The path (already normalized for the current OS).
+     *
+     * @var string
+     */
+    protected $path;
+
+    protected function __construct(string $path)
+    {
+        $this->path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    protected function checkExisting(): void
+    {
+        if (!is_file($this->path)) {
+            throw new RuntimeException("Unable to find the file {$this->path}");
+        }
+        if (!is_readable($this->path)) {
+            throw new RuntimeException("The ZIP archive {$this->path} is not readable");
+        }
+        $fd = fopen($this->path, 'rb');
+        if (!$fd) {
+            throw new RuntimeException("Failed to open the ZIP archive {$this->path}");
+        }
+        try {
+            $signature = fread($fd, strlen(self::FILE_SIGNATURE));
+            if ($signature !== self::FILE_SIGNATURE) {
+                throw new RuntimeException("The file {$this->path} doesn't seems a valid ZIP archive");
+            }
+        } finally {
+            fclose($fd);
+        }
+    }
+
+    protected function run(string $command, array $args)
+    {
+        $commandLine = $command . ' ' . implode(' ', $args) . ' 2>&1';
+        $output = [];
+        $rc = -1;
+        exec($commandLine, $output, $rc);
+        if ($rc !== 0) {
+            throw new RuntimeException(trim(implode("\n", $output)) ?: "{$command} command failed");
+        }
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/InfozipUnzipper.php
+++ b/src/Base/Archive/InfozipUnzipper.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use Pickle\Base\Interfaces;
+use RuntimeException;
+
+class InfozipUnzipper extends Infozip implements Interfaces\Archive\Unzipper
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::__construct()
+     */
+    public function __construct(string $path)
+    {
+        parent::__construct($path);
+        $this->checkExisting();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::__destruct()
+     */
+    public function __destruct(): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::extractTo()
+     */
+    public function extractTo(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (mkdir($path, 0777, true) !== true) {
+                throw new RuntimeException("Failed to create directory $path");
+            }
+        }
+        $originalCWD = getcwd();
+        if (chdir($path) !== true) {
+            throw new RuntimeException("Failed to enter directory {$path}");
+        }
+        try {
+            $this->run('unzip', [
+                escapeshellarg($this->path),
+            ]);
+        } finally {
+            chdir($originalCWD);
+        }
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/InfozipZipper.php
+++ b/src/Base/Archive/InfozipZipper.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use Pickle\Base\Interfaces;
+use Pickle\Base\Util\FileOps;
+use RuntimeException;
+use Throwable;
+
+class InfozipZipper extends Infozip implements Interfaces\Archive\Zipper
+{
+    use FileOps;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::__construct()
+     */
+    public function __construct(string $path, int $flags)
+    {
+        parent::__construct($path);
+        switch ($flags) {
+            case self::FLAG_OPEN:
+                $this->checkExisting();
+                break;
+            case self::FLAG_CREATE:
+                $this->create(false);
+                break;
+            case self::FLAG_CREATE_OVERWRITE:
+                $this->create(true);
+                break;
+            default:
+                throw new RuntimeException('Invalid value of $flags in ' . __METHOD__);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::addFromString($localname, $contents)
+     */
+    public function addFromString(string $localname, string $contents): void
+    {
+        $localname = ltrim(str_replace(DIRECTORY_SEPARATOR, '/', $localname), '/');
+        $this->createTempDir();
+        $tempDir = $this->getTempDir();
+        $dirname = dirname($localname);
+        if ($dirname !== '' && $dirname !== '.') {
+            if (mkdir($tempDir . '/' . $dirname, 0777, true) !== true) {
+                throw new RuntimeException('Failed to create a temporary directory');
+            }
+        }
+        if (file_put_contents($tempDir . '/' . $localname, $contents) === false) {
+            throw new RuntimeException('Failed to write a temporary file');
+        }
+        $originalCWD = getcwd();
+        if (chdir($tempDir) !== true) {
+            throw new RuntimeException("Failed to enter directory {$tempDir}");
+        }
+        try {
+            $this->run('zip', [
+                escapeshellarg($this->path),
+                escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $localname)),
+            ]);
+        } finally {
+            chdir($originalCWD);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::addFileWithoutPath()
+     */
+    public function addFileWithoutPath(string $path): void
+    {
+        $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+        if (!is_file($path)) {
+            throw new RuntimeException("Failed to find the file {$path}");
+        }
+        if (!is_readable($path)) {
+            throw new RuntimeException("The file {$path} is not readable");
+        }
+        $this->run('zip', [
+            '-j',
+            escapeshellarg($this->path),
+            escapeshellarg($path)
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::__destruct()
+     */
+    public function __destruct()
+    {
+        $this->cleanup();
+    }
+
+    private function create(bool $overwrite): void
+    {
+        if (file_exists($this->path)) {
+            if ($overwrite === false) {
+                throw new RuntimeException("The ZIP archive {$this->path} already exists");
+            }
+            if (unlink($this->path) === false) {
+                throw new RuntimeException("Failed to overwrite the ZIP archive {$this->path}");
+            }
+        }
+        $this->run([
+            '-j1',
+            escapeshellarg($this->path),
+            escapeshellarg(__FILE__)
+        ]);
+        try {
+            $this->run([
+                '-d',
+                escapeshellarg($this->path),
+                escapeshellarg(basename(__FILE__))
+            ]);
+        } catch (Throwable $x) {
+            unlink($this->path);
+            throw $x;
+        }
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/PHP.php
+++ b/src/Base/Archive/PHP.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use RuntimeException;
+use ZipArchive;
+
+abstract class PHP
+{
+    /**
+     * @var \ZipArchive
+     */
+    protected $zipArchive;
+
+    protected function __construct()
+    {
+        $this->zipArchive = new ZipArchive();
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    protected function open(string $path): void
+    {
+        if (!is_file($path)) {
+            throw new RuntimeException("Unable to find the file {$path}");
+        }
+        if (!is_readable($path)) {
+            throw new RuntimeException("The ZIP archive {$path} is not readable");
+        }
+        if ($this->zipArchive->open($path) !== true) {
+            $error = "Failed to open the ZIP archive {$path}";
+            $details = (string) $this->zipArchive->getStatusString();
+            if ($details !== '') {
+                $error .= ": {$details}";
+            }
+            throw new RuntimeException($error);
+        }
+    }
+
+    public function __destruct()
+    {
+        set_error_handler(static function() {}, -1);
+        $this->zipArchive->close();
+        restore_error_handler();
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/PHPUnzipper.php
+++ b/src/Base/Archive/PHPUnzipper.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use Pickle\Base\Interfaces;
+
+class PHPUnzipper extends PHP implements Interfaces\Archive\Unzipper
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::__construct()
+     */
+    public function __construct(string $path)
+    {
+        parent::__construct();
+        $this->open($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::extractTo()
+     */
+    public function extractTo(string $path): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Unzipper::__destruct()
+     */
+    public function __destruct(): void
+    {
+        parent::__destruct();
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Archive/PHPZipper.php
+++ b/src/Base/Archive/PHPZipper.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Archive;
+
+use Pickle\Base\Interfaces;
+use RuntimeException;
+use ZipArchive;
+
+class PHPZipper extends PHP implements Interfaces\Archive\Zipper
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::__construct()
+     */
+    public function __construct(string $path, int $flags)
+    {
+        parent::__construct();
+        switch ($flags) {
+            case self::FLAG_OPEN:
+                $this->open($path);
+                break;
+            case self::FLAG_CREATE:
+                $this->create($path, false);
+                break;
+            case self::FLAG_CREATE_OVERWRITE:
+                $this->create($path, true);
+                break;
+            default:
+                throw new RuntimeException('Invalid value of $flags in ' . __METHOD__);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::addFromString($localname, $contents)
+     */
+    public function addFromString(string $localname, string $contents): void
+    {
+        $localname = ltrim(str_replace(DIRECTORY_SEPARATOR, '/', $localname), '/');
+        if ($this->zipArchive->addFromString($localname, $contents) !== true) {
+            $error = "Failed to add a file to the ZIP archive starting from its contents";
+            $details = (string) $this->zipArchive->getStatusString();
+            if ($details !== '') {
+                $error .= ": {$details}";
+            }
+            throw new RuntimeException($error);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::addFileWithoutPath()
+     */
+    public function addFileWithoutPath(string $path): void
+    {
+        if (!is_file($path)) {
+            throw new RuntimeException("Failed to find the file {$path}");
+        }
+        if (!is_readable($path)) {
+            throw new RuntimeException("The file {$path} is not readable");
+        }
+        if ($this->zipArchive->addFile($path, basename($path)) !== true) {
+            $error = "Failed to add the file {$path} to the ZIP archive";
+            $details = (string) $this->zipArchive->getStatusString();
+            if ($details !== '') {
+                $error .= ": {$details}";
+            }
+            throw new RuntimeException($error);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Pickle\Base\Interfaces\Archive\Zipper::__destruct()
+     */
+    public function __destruct()
+    {
+        parent::__destruct();
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    private function create(string $path, bool $overwrite): void
+    {
+        $flags = ZipArchive::CREATE;
+        if ($overwrite === false) {
+            if (file_exists($path)) {
+                throw new RuntimeException("The ZIP archive {$path} already exists");
+            }
+        } else {
+            $flags |= ZipArchive::OVERWRITE;
+        }
+        if ($this->zipArchive->open($path, $flags) !== true) {
+            $error = "Failed to create the ZIP archive {$path}";
+            $details = (string) $this->zipArchive->getStatusString();
+            if ($details !== '') {
+                $error .= ": {$details}";
+            }
+            throw new RuntimeException($error);
+        }
+    }
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Interfaces/Archive/Unzipper.php
+++ b/src/Base/Interfaces/Archive/Unzipper.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Interfaces\Archive;
+
+interface Unzipper
+{
+    /**
+     * Initialize the instance, with the path of an existing zip file
+     *
+     * @param string $path
+     *
+     * @throws \RuntimeException in case of errors
+     */
+    public function __construct(string $path);
+
+    /**
+     * Extract the archive contents to a specific directory.
+     *
+     * @param string $path it will created if it does not exist
+     *
+     * @throws \RuntimeException in case of errors
+     */
+    public function extractTo(string $path): void;
+
+    /**
+     * Close the archive.
+     */
+    public function __destruct(): void;
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Base/Interfaces/Archive/Zipper.php
+++ b/src/Base/Interfaces/Archive/Zipper.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Pickle
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2015-2015, Pickle community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Pickle\Base\Interfaces\Archive;
+
+interface Zipper
+{
+    /**
+     * Instance creation flag: open an existing archive.
+     *
+     * @var int
+     */
+    public const FLAG_OPEN = 1;
+
+    /**
+     * Instance creation flag: create a new archive.
+     *
+     * @var int
+     */
+    public const FLAG_CREATE = 2;
+
+    /**
+     * Instance creation flag: create a new archive (overwriting an existing one if it already exists).
+     *
+     * @var int
+     */
+    public const FLAG_CREATE_OVERWRITE = 3;
+
+    /**
+     * Open an existing archive, or create a new one.
+     *
+     * @param string $path the path of the archive to be open/created
+     * @param int $flag FLAG_OPEN to open an existing archive, FLAG_CREATE/FLAG_CREATE_OVERWRITE to create a new archive
+     *
+     * @throws \RuntimeException in case of errors
+     */
+    public function __construct(string $path, int $flags);
+
+    /**
+     * Add a file the archive, without saving the directory names, only the file name.
+     *
+     * @param string $path the path to the file to be saved
+     */
+    public function addFileWithoutPath(string $path): void;
+
+    /**
+     * Add a file the archive using its contents.
+     *
+     * @throws \RuntimeException in case of errors
+     */
+    public function addFromString(string $localname, string $contents): void;
+
+    /**
+     * Close the archive.
+     */
+    public function __destruct();
+}
+
+/* vim: set tabstop=4 shiftwidth=4 expandtab: fdm=marker */

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -2,6 +2,7 @@
 
 namespace Pickle\Console;
 
+use Pickle\Base\Archive;
 use Symfony\Component\Console\Application as BaseApplication;
 
 class Application extends BaseApplication
@@ -52,7 +53,6 @@ class Application extends BaseApplication
             "dom",
             "openssl",
             "phar",
-            "zip",
         );
 
         foreach ($required_exts as $ext) {
@@ -60,5 +60,8 @@ class Application extends BaseApplication
                 Throw new \Exception("Extension '$ext' required but not loaded, full required list: " . implode(", ", $required_exts));
             }
         }
+
+        Archive\Factory::getUnzipperClassName();
+        Archive\Factory::getZipperClassName();
     }
 }

--- a/src/Package/PHP/Command/Install/Windows/Binary.php
+++ b/src/Package/PHP/Command/Install/Windows/Binary.php
@@ -39,6 +39,7 @@ namespace Pickle\Package\PHP\Command\Install\Windows;
 use Symfony\Component\Console\Output\OutputInterface as OutputInterface;
 use Pickle\Base\Util\FileOps;
 use Pickle\Engine;
+use Pickle\Base\Archive;
 use Pickle\Base\Util;
 
 class Binary
@@ -161,10 +162,9 @@ class Binary
     {
         $this->createTempDir($this->extName);
         $this->cleanup();
-        $zipArchive = new \ZipArchive();
-        if ($zipArchive->open($zipFile) !== true || !$zipArchive->extractTo($this->tempDir)) {
-            throw new \Exception('Cannot extract Zip archive <'.$zipFile.'>');
-        }
+        $zipClass = Archive\Factory::getUnzipperClassName();
+        $zipArchive = $zipClass($zipFile);
+        /** @var \Pickle\Base\Interfaces\Archive\Unzipper $zipArchive */
         $this->output->writeln('Extracting archives...');
         $zipArchive->extractTo($this->tempDir);
     }

--- a/src/Package/Util/Windows/DependencyLib.php
+++ b/src/Package/Util/Windows/DependencyLib.php
@@ -37,6 +37,7 @@
 namespace Pickle\Package\Util\Windows;
 
 use Symfony\Component\Console\Output\OutputInterface as OutputInterface;
+use Pickle\Base\Archive;
 use Pickle\Base\Util\FileOps;
 use Pickle\Base\Util;
 
@@ -268,10 +269,9 @@ class DependencyLib
     {
         $this->createTempDir();
         $this->cleanup();
-        $zipArchive = new \ZipArchive();
-        if ($zipArchive->open($zipFile) !== true || !$zipArchive->extractTo($this->tempDir)) {
-            throw new \Exception('Cannot extract Zip archive <'.$zipFile.'>');
-        }
+        $zipArchiveClass = Archive\Factory::getUnzipperClassName();
+        $zipArchive = new $zipArchiveClass($zipFile);
+        /** @var \Pickle\Base\Interfaces\Archive\Unzipper $zipArchive */
         $this->output->writeln('Extracting archives...');
         $zipArchive->extractTo($this->tempDir);
     }


### PR DESCRIPTION
What about using the system `zip`/`unzip` commands (if available) instead of the `ZipArchive` class?

Fix #195