### PR TITLE
Update composer.lock so that it matches composer.json

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4fc1a38f87cdecd9c1e9bce63c091a6",
+    "content-hash": "b9c02d83a642ebcba1001e3441d1960f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4708,8 +4708,7 @@
         "ext-simplexml": "*",
         "ext-json": "*",
         "ext-dom": "*",
-        "ext-openssl": "*",
-        "ext-zip": "*"
+        "ext-openssl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Because two different pull requests touched the composer.json/composer.lock pair, they are now not in sync.

This can be seen when running `composer install`: we see this warning

```
Warning: The lock file is not up to date with the latest changes in composer.json.
You may be getting outdated dependencies. It is recommended that you run `composer update` or
`composer update <package name>`.
```

Let's fix this warning.