### PR TITLE
Support reading version from headers in form PHP_<NAME>_EXT_VERSION

### DIFF
--- a/features/pecl/install-extensions.feature
+++ b/features/pecl/install-extensions.feature
@@ -20,6 +20,7 @@ Feature: download and install PECL extensions
       | apc       | APC       |
       | apcu      | apcu      |
       | mongo     | mongo     |
+      | zstd      | zstd      |
 
   Scenario Outline: Does NOT install extensions from PECL repository having wrong version in source code
     Given I run "pickle install <extension>-<version> --dry-run"


### PR DESCRIPTION
When we extract the package version from C header files, we currently look for `#define`s like:

- `#define PHP_PKGNAME_VERSION "..."`
- `#define PKGNAME_VERSION "..."`

(where `PKGNAME` is the upper case name of the package)

BTW some package also use this syntax:

- `#define PHP_PKGNAME_EXT_VERSION "..."`

(see for example the [`zstd` extension](https://github.com/kjdev/php-ext-zstd/blob/0.10.0/php_zstd.h#L27)).

So, what about using a regular expression that makes both the `PHP_` and `EXT_` parts optional?