### PR TITLE
Check for zip/unzip capability only when needed

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -38,7 +38,6 @@ namespace Pickle\Console;
 
 use Exception;
 use Phar;
-use Pickle\Base\Archive;
 use Symfony\Component\Console\Application as BaseApplication;
 
 class Application extends BaseApplication
@@ -97,8 +96,5 @@ class Application extends BaseApplication
                 throw new Exception("Extension '{$ext}' required but not loaded, full required list: " . implode(', ', $required_exts));
             }
         }
-
-        Archive\Factory::getUnzipperClassName();
-        Archive\Factory::getZipperClassName();
     }
 }

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -38,6 +38,7 @@ namespace Pickle\Console\Command;
 
 use Exception;
 use Pickle\Base\Abstracts\Console\Command\BuildCommand;
+use Pickle\Base\Archive\Factory;
 use Pickle\Base\Util;
 use Pickle\Engine;
 use Pickle\Package\Command\Install;
@@ -119,6 +120,7 @@ class InstallerCommand extends BuildCommand
      */
     protected function binaryInstallWindows($path, InputInterface $input, OutputInterface $output)
     {
+        Factory::getUnzipperClassName(); // Be sure we have a way to unzip files
         $php = Engine::factory();
         $table = new Table($output);
         $table

--- a/src/Console/Command/ReleaseCommand.php
+++ b/src/Console/Command/ReleaseCommand.php
@@ -38,6 +38,7 @@ namespace Pickle\Console\Command;
 
 use Exception;
 use Pickle\Base\Abstracts\Console\Command\BuildCommand;
+use Pickle\Base\Archive\Factory;
 use Pickle\Base\Interfaces;
 use Pickle\Base\Util;
 use Pickle\Package\Command\Release;
@@ -87,6 +88,9 @@ class ReleaseCommand extends BuildCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (DIRECTORY_SEPARATOR === '\\' || $input->getOption('pack-logs')) {
+            Factory::getZipperClassName(); // Be sure we have a way to zip files
+        }
         $helper = $this->getHelper('package');
         Util\TmpDir::set($input->getOption('tmp-dir'));
 


### PR DESCRIPTION
We only need zip/unzip capabilities in some cases, so let's avoid always requiring them...