### PR TITLE
Add a simple hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ setlocal DISABLEDELAYEDEXPANSION
 c:\path\to\php.exe "c:\path\to\pickle.phar" %*
 ```
 
+On linux systems, you can create shortcut, so command will be available globally:
+```sh
+$ sudo cp pickle /usr/bin
+```
+
 If someone would be kind enough to write an installer script, we would be eternally thankful :)
 
 Introduction


### PR DESCRIPTION
Many people out there (probably most of users who use unix-systems) will need `pickle` command to be available globally in terminal. That simple hint be useful for users.