### PR TITLE
Allow passing configure options without being a real file

### DIFF
--- a/src/Base/Abstracts/Console/Command/BuildCommand.php
+++ b/src/Base/Abstracts/Console/Command/BuildCommand.php
@@ -101,7 +101,7 @@ abstract class BuildCommand extends Command
         $force_opts = $input->getOption('with-configure-options');
 
         if ($force_opts) {
-            if (!file_exists($force_opts) || !is_file($force_opts) || !is_readable($force_opts)) {
+            if (!file_exists($force_opts) || !is_readable($force_opts)) {
                 throw new Exception("File '{$force_opts}' is unusable");
             }
 

--- a/src/Base/Abstracts/Console/Command/BuildCommand.php
+++ b/src/Base/Abstracts/Console/Command/BuildCommand.php
@@ -101,7 +101,7 @@ abstract class BuildCommand extends Command
         $force_opts = $input->getOption('with-configure-options');
 
         if ($force_opts) {
-            if (!file_exists($force_opts) || !is_readable($force_opts)) {
+            if (!file_exists($force_opts) || !(is_file($force_opts) || is_link($force_opts)) || !is_readable($force_opts)) {
                 throw new Exception("File '{$force_opts}' is unusable");
             }
 


### PR DESCRIPTION
By removing the `is_file` check we allow installing extensions like this:

```bash
bin/pickle install --source \
    --with-configure-options <(echo --with-rdkafka=/opt/homebrew/opt/librdkafka) rdkafka
```

No more need to create a file with the options first 🎉 