### PR TITLE
Follows PECL stability strategy

### DIFF
--- a/src/Package/PHP/Convey/Command/Pecl.php
+++ b/src/Package/PHP/Convey/Command/Pecl.php
@@ -78,10 +78,10 @@ class Pecl extends Abstracts\Package\Convey\Command implements Interfaces\Packag
 
         if (isset($matches['stability']) && $matches['stability'] !== '') {
             $this->stability = $matches['stability'];
-            $this->url .= '-' . $matches['stability'];
         } else {
             $this->stability = 'stable';
         }
+        $this->url .= '-' . $this->stability;
 
         if (isset($matches['version']) && $matches['version'] !== '') {
             $this->url .= '/' . $matches['version'];


### PR DESCRIPTION
With current pickle version 0.7.7, when we try to install a PECL package what have is latest version as unstable (i.e `amqp`)

Two last versions are : 
| Version | State | Release data
| --- | --- | ---
| 1.11.0beta | beta | 2021-03-10
| 1.10.2 | stable | 2020-04-05

When we run following command `bin/pickle amqp`, we expect to have the latest stable version, but actually we get 

```
  - Installing amqp (latest-stable): Downloading (100%)
+-----------------------------------+------------+
| Package name                      | amqp       |
| Package version (current release) | 1.11.0beta |
| Package status                    | beta       |
+-----------------------------------+------------+
```

We expect to have instead 

```
  - Installing amqp (latest-stable): Downloading (100%)
+-----------------------------------+--------+
| Package name                      | amqp   |
| Package version (current release) | 1.10.2 |
| Package status                    | stable |
+-----------------------------------+--------+
```

Workaround is possible if we force stability with following command `bin/pickle amqp-stable`

This PR fixed this issue

