### PR TITLE
Don't compress PHP files when generating pickle.phar

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -2,8 +2,7 @@
     "alias": "pickle.phar",
     "chmod": "0755",
     "compactors": [
-        "Herrera\\Box\\Compactor\\Json",
-        "Herrera\\Box\\Compactor\\Php"
+        "Herrera\\Box\\Compactor\\Json"
     ],
     "directories": ["src", "vendor/composer/composer/res", "vendor/composer/ca-bundle"],
     "finder": [{


### PR DESCRIPTION
We need PHP comments like #[\ReturnTypeWillChange]