### PR TITLE
fix issue#253 window install failed

### DIFF
--- a/src/Base/Archive/PHPUnzipper.php
+++ b/src/Base/Archive/PHPUnzipper.php
@@ -68,6 +68,7 @@ class PHPUnzipper extends PHP implements Interfaces\Archive\Unzipper
      */
     public function extractTo(string $path): void
     {
+        $this->zipArchive->extractTo($path);
     }
 }
 

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -102,8 +102,7 @@ class InstallerCommand extends BuildCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Override detected version (no value - or empty value - to use the version from package.xml)'
-            )
-        ;
+            );
 
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
             $this->addOption(
@@ -133,20 +132,17 @@ class InstallerCommand extends BuildCommand
                 ['<info>Extension dir</info>', $php->getExtensionDir()],
                 ['<info>php.ini</info>', $php->getIniPath()],
             ])
-            ->render()
-        ;
+            ->render();
 
         $inst = Install::factory($path);
         $progress = new ProgressBar($output, 100);
 
         $inst->setProgress($progress);
-        $inst->setInput($input);
         $inst->setOutput($output);
         $inst->install();
 
         $deps_handler = new Windows\DependencyLib($php);
         $deps_handler->setProgress($progress);
-        $deps_handler->setInput($input);
         $deps_handler->setOutput($output);
 
         $helper = $this->getHelperSet()->get('question');

--- a/src/Console/Command/InstallerCommand.php
+++ b/src/Console/Command/InstallerCommand.php
@@ -102,7 +102,8 @@ class InstallerCommand extends BuildCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Override detected version (no value - or empty value - to use the version from package.xml)'
-            );
+            )
+        ;
 
         if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
             $this->addOption(
@@ -132,7 +133,8 @@ class InstallerCommand extends BuildCommand
                 ['<info>Extension dir</info>', $php->getExtensionDir()],
                 ['<info>php.ini</info>', $php->getIniPath()],
             ])
-            ->render();
+            ->render()
+        ;
 
         $inst = Install::factory($path);
         $progress = new ProgressBar($output, 100);

--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -213,8 +213,8 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
 
         foreach ($info as $s) {
             if (
-                strpos($s, 'Loaded Configuration File') !== false ||
-                strpos($s, 'Additional .ini files parsed') !== false
+                strpos($s, 'Loaded Configuration File') !== false
+                || strpos($s, 'Additional .ini files parsed') !== false
             ) {
                 [, $iniPath] = explode('=>', $s);
                 if (strtolower(trim($iniPath)) === '(none)') {

--- a/src/Engine/PHP.php
+++ b/src/Engine/PHP.php
@@ -212,16 +212,18 @@ class PHP extends Abstracts\Engine implements Interfaces\Engine
         $iniPath = '';
 
         foreach ($info as $s) {
-            if (strpos($s, 'Loaded Configuration File') !== false) {
+            if (
+                strpos($s, 'Loaded Configuration File') !== false ||
+                strpos($s, 'Additional .ini files parsed') !== false
+            ) {
                 [, $iniPath] = explode('=>', $s);
-                if ($iniPath === '(None)') {
+                if (strtolower(trim($iniPath)) === '(none)') {
                     $iniPath = '';
+                    continue;
                 }
-
                 break;
             }
         }
-
         $iniPath = trim($iniPath);
         if ($iniPath == '') {
             throw new Exception('Cannot detect php.ini directory');

--- a/src/Package/PHP/Command/Install/Windows/Binary.php
+++ b/src/Package/PHP/Command/Install/Windows/Binary.php
@@ -199,7 +199,7 @@ class Binary
         $this->createTempDir($this->extName);
         $this->cleanup();
         $zipClass = Archive\Factory::getUnzipperClassName();
-        $zipArchive = $zipClass($zipFile);
+        $zipArchive = new $zipClass($zipFile);
         /** @var \Pickle\Base\Interfaces\Archive\Unzipper $zipArchive */
         $this->output->writeln('Extracting archives...');
         $zipArchive->extractTo($this->tempDir);
@@ -283,7 +283,7 @@ class Binary
             if (substr($basename, 0, 4) == 'php_') {
                 $this->extDll[] = $basename;
                 $this->output->writeln("copying {$dll} to " . $dest . "\n");
-                $success = copy($dll, $this->php->getExtensionDir() . '/' . $basename);
+                $success = copy($dll, $dest);
                 if (!$success) {
                     throw new Exception('Cannot copy DLL <' . $dll . '> to <' . $dest . '>');
                 }

--- a/src/Package/Util/Windows/DependencyLib.php
+++ b/src/Package/Util/Windows/DependencyLib.php
@@ -193,7 +193,8 @@ class DependencyLib
 
     private function checkDepListerExe()
     {
-        $ret = exec('deplister.exe ' . $this->php->getPath() . ' .');
+        $deplister = dirname($this->php->getPath()) . DIRECTORY_SEPARATOR . 'deplister.exe ';
+        $ret = exec($deplister . $this->php->getPath() . ' .');
         if (empty($ret)) {
             $depexe = @file_get_contents(self::DEPLISTER_URL);
             if (!$depexe) {
@@ -210,7 +211,8 @@ class DependencyLib
     private function getDllsForBinary($binary)
     {
         $out = [];
-        $ret = exec('deplister.exe ' . escapeshellarg($binary) . ' .', $out);
+        $deplister = dirname($this->php->getPath()) . DIRECTORY_SEPARATOR . 'deplister.exe ';
+        $ret = exec($deplister . escapeshellarg($binary) . ' .', $out);
         if (empty($ret) || !$ret) {
             throw new RuntimeException('Error while running deplister.exe');
         }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/pickle/issues/253

1. Remove undefined method Binary::setInput and DependencyLib::setInput
2. Support Additional .ini Path
3. Support deplister.exe not in Path
4. Implementing PHPUnzipper function exttactTo