### PR TITLE
Optimize memory usage when logging output of an executed command.

### DIFF
--- a/src/Base/Abstracts/Package/Build.php
+++ b/src/Base/Abstracts/Package/Build.php
@@ -41,6 +41,7 @@ use Pickle\Base\Archive;
 use Pickle\Base\Interfaces;
 use Pickle\Base\Interfaces\Package;
 use Pickle\Base\Util\FileOps;
+use function rtrim;
 
 abstract class Build
 {
@@ -191,11 +192,13 @@ abstract class Build
             );
         }
 
-        $out = [];
+        $out = '';
         while ($line = fgets($pp, 1024)) {
-            $out[] = rtrim($line);
+            $out .= rtrim($line) . "\n";
         }
-        $this->log(2, implode("\n", $out), $hint);
+
+        $this->log(2, rtrim($out), $hint);
+        unset($out);
 
         $exitCode = is_resource($pp) ? pclose($pp) : -1;
 


### PR DESCRIPTION

**Problem**

During command execution, output gets buffered in `$out` array for further logging.
The content of the array is then composed in a single log message.

Use of array leads to unnecessary memory consumption.

**Solution**

Do not buffer command execution output in an array; instead, compose log message right away.